### PR TITLE
fix: paginateData swagger

### DIFF
--- a/src/domain/member/member.controller.ts
+++ b/src/domain/member/member.controller.ts
@@ -64,6 +64,9 @@ import {
 import {
     UpdateMemberAuthorityRequestDto, 
 } from "@member/dto/req/update-member-authority.request.dto";
+import {
+    ApiCustomFilterResponseDecorator, 
+} from "@root/util/api-custom-filter-response.decotrator";
 
 @ApiTags("members")
 @ApiExtraModels(CustomResponse)
@@ -79,7 +82,7 @@ export class MemberController {
         summary: "멤버 Paginate 조회",
         description: "멤버의 정보를 Paginate 해서, 조회할 수 있다.",
     })
-    @ApiCustomResponseDecorator(PaginateData<GetMemberResponseDto>)
+    @ApiCustomFilterResponseDecorator(GetMemberResponseDto)
     @HttpCode(HttpStatus.OK)
     @Get()
     async getMemberList(@Query() paginateDto: PaginateRequestDto)
@@ -94,7 +97,7 @@ export class MemberController {
         summary: "멤버 Detail Paginate 조회",
         description: "멤버의 세부 정보(가입 여부, 권한)를 포함한 정보를 Paginate 해서, 조회할 수 있다.",
     })
-    @ApiCustomResponseDecorator(PaginateData<GetMemberDetailResponseDto>)
+    @ApiCustomFilterResponseDecorator(GetMemberDetailResponseDto)
     @HttpCode(HttpStatus.OK)
     @Get("/detail")
     async getMemberDetailList(

--- a/src/domain/reserve/reserve.controller.ts
+++ b/src/domain/reserve/reserve.controller.ts
@@ -47,6 +47,9 @@ import {
 import {
     ReserveOptionDto, 
 } from "@root/interface/request/reserve-option.dto";
+import {
+    ApiCustomFilterResponseDecorator, 
+} from "@root/util/api-custom-filter-response.decotrator";
 
 @ApiTags("reserve")
 @ApiExtraModels(CustomResponse)
@@ -91,7 +94,7 @@ export class ReserveController {
         description: "본인이 예약한 정보를 Paginate된 예약List로 조회 할 수 있는 API",
     })
     @PermissionDecorator(MemberAuthority.ADMIN, MemberAuthority.MANAGER, MemberAuthority.USER)
-    @ApiCustomResponseDecorator(PaginateData<GetReserveResponseDto>)
+    @ApiCustomFilterResponseDecorator(GetReserveResponseDto)
     @HttpCode(HttpStatus.OK)
     @Get("/my-reserve")
     async getMyReserveList(@Query() paginateDto: PaginateRequestDto, @Request() req)
@@ -106,7 +109,7 @@ export class ReserveController {
         description: "모든 예약의 Paginate된 예약 Log 정보를 조회 할 수 있는 API",
     })
     @PermissionDecorator(MemberAuthority.ADMIN, MemberAuthority.MANAGER)
-    @ApiCustomResponseDecorator(PaginateData<GetReserveLogResponseDto>)
+    @ApiCustomFilterResponseDecorator(GetReserveLogResponseDto)
     @HttpCode(HttpStatus.OK)
     @Get("/logs")
     async getReserveLogList(@Query() paginateDto: PaginateRequestDto)
@@ -132,11 +135,11 @@ export class ReserveController {
     }
 
     @ApiOperation({
-        summary: "예약 조회List API",
+        summary: "예약 조회 List API",
         description: "SpaceId 별, Paginate된 예약List를 조회 할 수 있는 API",
     })
     @PermissionDecorator(MemberAuthority.ADMIN, MemberAuthority.MANAGER, MemberAuthority.USER)
-    @ApiCustomResponseDecorator(PaginateData<GetReserveResponseDto>)
+    @ApiCustomFilterResponseDecorator(GetReserveResponseDto)
     @HttpCode(HttpStatus.OK)
     @Get()
     async getReserveList(@Query() paginateDto: PaginateRequestDto, @Query() optionDto: ReserveOptionDto)

--- a/src/domain/space/space.controller.ts
+++ b/src/domain/space/space.controller.ts
@@ -61,6 +61,9 @@ import {
 import {
     PaginateRequestDto, 
 } from "@root/interface/request/paginate.request.dto";
+import {
+    ApiCustomFilterResponseDecorator, 
+} from "@root/util/api-custom-filter-response.decotrator";
 
 @ApiTags("spaces")
 @ApiExtraModels(CustomResponse)
@@ -187,7 +190,7 @@ export class SpaceController {
         summary: "공간 List 조회.",
         description: "공간의 정보를 Paginate해서 조회할 수 있다.",
     })
-    @ApiCustomResponseDecorator(PaginateData<GetSpaceResponseDto>)
+    @ApiCustomFilterResponseDecorator(GetSpaceResponseDto)
     @HttpCode(HttpStatus.OK)
     @Get()
     async getSpaceList(@Query() paginateDto: PaginateRequestDto)

--- a/src/interface/response/paginate.data.ts
+++ b/src/interface/response/paginate.data.ts
@@ -1,5 +1,21 @@
+import {
+    ApiProperty, 
+} from "@nestjs/swagger";
+
 export class PaginateData<T> {
     data: T[];
+
+    @ApiProperty({
+        type: Object,
+        description: "Page Metadata",
+        example: {
+            page: 1,
+            take: 1,
+            totalCount: 9,
+            totalPage: 1,
+            hasNextPage: false,
+        },
+    })
     meta: {
         page: number;
         take: number;

--- a/src/util/api-custom-filter-response.decotrator.ts
+++ b/src/util/api-custom-filter-response.decotrator.ts
@@ -1,0 +1,48 @@
+import {
+    applyDecorators, Type, 
+} from "@nestjs/common";
+import {
+    ApiExtraModels, ApiResponse, getSchemaPath, 
+} from "@nestjs/swagger";
+import {
+    CustomResponse, 
+} from "@root/interface/response/custom-response";
+import {
+    PaginateData, 
+} from "@root/interface/response/paginate.data";
+
+export const ApiCustomFilterResponseDecorator = <TModel extends Type<any>>(model: TModel) => {
+    return applyDecorators(
+        ApiExtraModels(CustomResponse, PaginateData, model),
+        ApiResponse({
+            schema: {
+                allOf: [
+                    {
+                        $ref: getSchemaPath(CustomResponse),
+                    },
+                    {
+                        properties: {
+                            data: {
+                                allOf: [
+                                    {
+                                        $ref: getSchemaPath(PaginateData),
+                                    },
+                                    {
+                                        properties: {
+                                            data: {
+                                                type: "array",
+                                                items: {
+                                                    $ref: getSchemaPath(model),
+                                                },
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+        })
+    );
+};


### PR DESCRIPTION
paginateData가 swagger에서 보이지 않아서 해당하는 Decorator를 만들어서 Paginate된 환경에서도 적용되도록 함

# 작업 분류
<!--이 PR에서 작업한 항목을 모두 체크 -->
- [x] 버그 수정

<br>

# 작업 내용 요약
<!--여기에 작성-->
paginateData조회를 위한 데코레이터 작성, Controller에 해당하는 Swagger 조회되도록 변경

<br>

# 관련 자료
<!--여기에 작성-->

<br>